### PR TITLE
Handle string-encoded horaires JSON

### DIFF
--- a/assets/js/module-horaires.js
+++ b/assets/js/module-horaires.js
@@ -591,7 +591,16 @@ console.log("✅ ID pharmacie :", pharmacieId);
 
 // Hydratation
 if (data.fields?.horaires) {
-  hydrateModuleFromJson(data.fields.horaires);
+  let horaires = data.fields.horaires;
+  if (typeof horaires === "string") {
+    try {
+      horaires = JSON.parse(horaires);
+    } catch (e) {
+      console.error("Impossible de parser les horaires", e);
+      horaires = null;
+    }
+  }
+  if (horaires) hydrateModuleFromJson(horaires);
 }
 
 });


### PR DESCRIPTION
## Summary
- adjust hydration code to parse horaires when sent as a string

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684552b3d10083309daa7dfeaa389b58