### PR TITLE
Expose schedule block builders globally

### DIFF
--- a/assets/js/module-horaires.js
+++ b/assets/js/module-horaires.js
@@ -527,9 +527,12 @@ container.insertBefore(status, container.querySelector('.plages'));
   }
 };
 
-    div.querySelectorAll(".heure").forEach(input => initFlatpickrHeure(input));
-    return div;
+  div.querySelectorAll(".heure").forEach(input => initFlatpickrHeure(input));
+  return div;
   }
+
+  window.creerBlocJour = creerBlocJour;
+  window.makePlage = makePlage;
 
   document.getElementById("ajouter-exception").addEventListener("click", () => {
     const startInput = document.getElementById("date-exception-start");


### PR DESCRIPTION
## Summary
- expose `creerBlocJour` and `makePlage` on `window`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845552f73808330af32e01b720c9420